### PR TITLE
fix: update welcome message in start handler for clarity

### DIFF
--- a/src/bot/handlers/start.py
+++ b/src/bot/handlers/start.py
@@ -9,7 +9,7 @@ async def start_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
     welcome_message = (
         "歡迎使用派星機！\n\n"
         "你可以：\n"
-        "• 直接輸入你的心情，我會幫你找適合的梗圖\n"
+        "• 直接輸入關鍵字，我會幫你找適合的梗圖\n"
         "• 輸入 /random 隨機獲得一張梗圖"
     )
 


### PR DESCRIPTION
- Changed wording in the welcome message from "直接輸入你的心情" to "直接輸入關鍵字" to better reflect the intended user input for meme searches.